### PR TITLE
Fix for parsing logic break when inputs key not found in some abi

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export const parseLog = (logs, eventAbis, filter = {}) => {
   const parsers = filteredAbis.map(thisAbi => {
     // if the key inputs is not found, then ignore the entry
     if (!thisAbi.inputs) {
-        return false;
+      return false
     }
 
     const key = JSON.stringify(thisAbi)

--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,10 @@ export const parseLog = (logs, eventAbis, filter = {}) => {
   const filteredAbis = eventAbis.filter(({ anonymous }) => !anonymous)
 
   const parsers = filteredAbis.map(thisAbi => {
-	//if the key inputs is not found, then ignore the entry
-	if(!thisAbi.inputs) {
-		return false;
-	}
+    // if the key inputs is not found, then ignore the entry
+    if (!thisAbi.inputs) {
+        return false;
+    }
 
     const key = JSON.stringify(thisAbi)
 

--- a/src/index.js
+++ b/src/index.js
@@ -96,9 +96,8 @@ export const parseLog = (logs, eventAbis, filter = {}) => {
   let filteredLogs = logs
 
   if (Object.keys(filter).length) {
-    filteredLogs = logs.filter(({ address, blockNumber }) => (
+    filteredLogs = logs.filter(({ address }) => (
       (undefined === filter.address || address.toLowerCase() === filter.address.toLowerCase())
-        && (undefined === filter.blockNumber || blockNumber === filter.blockNumber)
     ))
   }
 
@@ -109,14 +108,10 @@ export const parseLog = (logs, eventAbis, filter = {}) => {
           soFar.push({
             name,
             address: log.address,
-            blockNumber: log.blockNumber,
-            blockHash: log.blockHash,
-            transactionHash: log.transactionHash,
-            args: parseArgs(log),
-            log
+            args: parseArgs(log)
           })
         } catch (err) {
-          console.error(`Error parsing args for event ${name} in block ${log.blockNumber}`)
+          console.error(`Error parsing args for event ${name}`)
         }
       }
       return soFar

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,11 @@ export const parseLog = (logs, eventAbis, filter = {}) => {
   const filteredAbis = eventAbis.filter(({ anonymous }) => !anonymous)
 
   const parsers = filteredAbis.map(thisAbi => {
+	//if the key inputs is not found, then ignore the entry
+	if(!thisAbi.inputs) {
+		return false;
+	}
+
     const key = JSON.stringify(thisAbi)
 
     if (!cachedParsers[key]) {


### PR DESCRIPTION
Updated abi filter logic to ignore entry from abi array if the key named 'inputs' is not found. For example, the abi data for contract address 0xB9BB492938804AF56EFf197aaC151C4399ba7dD5 as shown below has the last entry as `"type": "fallback"` and there is no 'inputs' key.

> [
    {
        "type": "function",
        "name": "sendMultiSigToken",
        "inputs": [
            {
                "name": "toAddress",
                "type": "address"
            },
            {
                "name": "value",
                "type": "uint256"
            },
            {
                "name": "tokenContractAddress",
                "type": "address"
            },
            {
                "name": "expireTime",
                "type": "uint256"
            },
            {
                "name": "sequenceId",
                "type": "uint256"
            },
            {
                "name": "signature",
                "type": "bytes"
            }
        ],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "signers",
        "inputs": [
            {
                "name": "param1",
                "type": "uint256"
            }
        ],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "flushForwarderTokens",
        "inputs": [
            {
                "name": "forwarderAddress",
                "type": "address"
            },
            {
                "name": "tokenContractAddress",
                "type": "address"
            }
        ],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "sendMultiSig",
        "inputs": [
            {
                "name": "toAddress",
                "type": "address"
            },
            {
                "name": "value",
                "type": "uint256"
            },
            {
                "name": "data",
                "type": "bytes"
            },
            {
                "name": "expireTime",
                "type": "uint256"
            },
            {
                "name": "sequenceId",
                "type": "uint256"
            },
            {
                "name": "signature",
                "type": "bytes"
            }
        ],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "isSigner",
        "inputs": [
            {
                "name": "param1",
                "type": "address"
            }
        ],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "getNextSequenceId",
        "inputs": [],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "createForwarder",
        "inputs": [],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "safeMode",
        "inputs": [],
        "stateMutability": "nonpayable"
    },
    {
        "type": "function",
        "name": "activateSafeMode",
        "inputs": [],
        "stateMutability": "nonpayable"
    },
    {
        "type": "fallback",
        "stateMutability": "payable"
    }
]